### PR TITLE
Add media url to the project

### DIFF
--- a/ghardailo/settings.py
+++ b/ghardailo/settings.py
@@ -110,6 +110,10 @@ STATICFILES_DIRS = [
 
 ]
 
+# Media Files
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
+
 # Default primary key field type
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 

--- a/ghardailo/urls.py
+++ b/ghardailo/urls.py
@@ -7,3 +7,10 @@ urlpatterns = [
     path('', include('accounts.urls')),
     # path('', include('Customer.urls'))
 ]
+
+# Static & Media Management Fiels For Debug Mode Only.
+if settings.DEBUG:
+    urlpatterns += static(settings.STATIC_URL,
+                          document_root=settings.STATIC_ROOT)
+    urlpatterns += static(settings.MEDIA_URL,
+                          document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
### Adding Media URL to project.
Static & Media are different things. 

- Static are the files that will rarely change
Files like .html, .css, website logo, hero image never change so they should be inside a static file

- Media Files
The files that change regularly
Files like user profile picture, gallery, etc.